### PR TITLE
Allow use of secret files.

### DIFF
--- a/patreon-responder/config.py
+++ b/patreon-responder/config.py
@@ -1,0 +1,54 @@
+import os
+
+
+def _get_config_env(key):
+    """
+    Check the environment variables for the key.
+    """
+    return os.getenv(key)
+
+
+def _get_config_env_file(key):
+    """
+    Check the environment variables for the key with the
+    suffix of "_file" and if it is set then read the file.
+    """
+    filename = os.getenv(key + "_file")
+    if not filename:
+        return None
+    with open(filename) as file:
+        return file.read()
+
+
+SECRET_LOCATIONS = [
+    "/run/secrets/",
+    "/var/openfaas/secrets/",
+]
+
+
+def _get_config_secret_locations(key):
+    """
+    Check the folders listed in SECRET_LOCATIONS for a file
+    named the same as the key and return its contents.
+    """
+    for prefix in SECRET_LOCATIONS:
+        filename = prefix+key
+        if os.path.isfile(filename):
+            with open(filename) as file:
+                return file.read()
+    return None
+
+
+AVAILABLE_LOOKUPS = [
+    _get_config_env,
+    _get_config_env_file,
+    _get_config_secret_locations,
+]
+
+
+def get_config(key, default=None):
+    for lookup in AVAILABLE_LOOKUPS:
+        ret = lookup(key)
+        if ret is not None:
+            return ret
+    return default

--- a/patreon-responder/handler.py
+++ b/patreon-responder/handler.py
@@ -1,17 +1,17 @@
-import os
+from os import getenv
 import json
 from validate import *
-import hmac
+from config import get_config
 import requests
 import tweepy
 
 def handle(st):
     req = json.loads(st)
 
-    event_type = os.getenv("Http_X_Patreon_Event")
-    sender_digest = os.getenv("Http_X_Patreon_Signature")
+    event_type = getenv("Http_X_Patreon_Event")
+    sender_digest = getenv("Http_X_Patreon_Signature")
 
-    key = os.getenv("webhook_secret")
+    key = get_config("webhook_secret")
 
     print("Event: " + event_type)
 
@@ -20,7 +20,7 @@ def handle(st):
         return
 
     if event_type == "pledges:delete":
-        display = os.getenv("display_removed", "0")
+        display = get_config("display_removed", "0")
 
         if display == "1":
             patron_link = req["data"]["relationships"]["patron"]["links"]["related"]
@@ -36,8 +36,8 @@ def handle(st):
 
                 print(tweet)
 
-                auth = tweepy.OAuthHandler(os.environ["consumer_key"], os.environ["consumer_secret"])
-                auth.set_access_token(os.environ["access_token"], os.environ["access_token_secret"])
+                auth = tweepy.OAuthHandler(get_config("consumer_key"), get_config("consumer_secret"))
+                auth.set_access_token(get_config("access_token"), get_config("access_token_secret"))
 
                 api = tweepy.API(auth)
 
@@ -64,8 +64,8 @@ def handle(st):
 
             print(tweet)
 
-            auth = tweepy.OAuthHandler(os.environ["consumer_key"], os.environ["consumer_secret"])
-            auth.set_access_token(os.environ["access_token"], os.environ["access_token_secret"])
+            auth = tweepy.OAuthHandler(get_config("consumer_key"), get_config("consumer_secret"))
+            auth.set_access_token(get_config("access_token"), get_config("access_token_secret"))
 
             api = tweepy.API(auth)
 


### PR DESCRIPTION
This PR will add the ability to use secrets instead of having environment variables contain secret information.

For example `get_config("consumer_key")` will first lookup to see if `consumer_key` is in the environment if so then return it.

Otherwise if key `consumer_key_file` exists we will read the files content and return it.

Otherwise we will search `/run/secrets/consumer_key` and `/var/openfaas/secrets/consumer_key` and if any of them exist we will return the files content.

If all these fail then the second argument to `get_config` is returned and by default that is `None`



p.s I'm not a Python developer so this may be way off.

fixes #3 